### PR TITLE
Fix requirements, XVFB installation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # DALL-E FOR FREE!
 
-## P.S : you may need to `pip install -U webdriver-manager`
-
 Use OpenAI's DALL-E for free
  
 With dalle43 you can use  OpenAi's DALL-E for free
@@ -10,8 +8,12 @@ dalle43 is only available for Linux systems.
 
 To use dalle43 follow the instructions below:
 
-1) install xvfb (mandatory) : `sudo apt-get install xvfb`
-2) install dalle43 : `pip install -U dalle43`
+1) install xvfb (mandatory):
+    - Debian-based (Ubuntu, PopOS, Linux Mint, etc.) - `sudo apt-get install xvfb`
+    - Arch-based (ArchLinux, Manjaro Linux, etc.) - `sudo pacman -S xorg-server-xvfb`
+    - RHEL and based (CentOS, Fedora, etc.) - `sudo yum install xorg-x11-server-Xvfb`
+
+    2) install dalle43 : `pip install -U dalle43`
 
 You can now generate images with DALL-E for free by running `python3 -m dalle43.dalle43` and entering the description of the image you want to generate. The images will be saved in the `/home/USER/Pictures/generated_images` folder
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To use dalle43 follow the instructions below:
     - Arch-based (ArchLinux, Manjaro Linux, etc.) - `sudo pacman -S xorg-server-xvfb`
     - RHEL and based (CentOS, Fedora, etc.) - `sudo yum install xorg-x11-server-Xvfb`
 
-    2) install dalle43 : `pip install -U dalle43`
+2) install dalle43 : `pip install -U dalle43`
 
 You can now generate images with DALL-E for free by running `python3 -m dalle43.dalle43` and entering the description of the image you want to generate. The images will be saved in the `/home/USER/Pictures/generated_images` folder
 

--- a/dalle43.egg-info/requires.txt
+++ b/dalle43.egg-info/requires.txt
@@ -1,2 +1,4 @@
 PyVirtualDisplay==3.0
 selenium==4.8.2
+requests==2.28.2
+webdriver-manager==3.8.5


### PR DESCRIPTION
After installing this package `requests` needs to be installed manually, so I'd added `requests` and `webdriver-manager` to package requirements.

I'd added `xvfb` package installation commands to some other Linux distributives.